### PR TITLE
Fix link to webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Alexandra Patriksson and David van der Spoel, A temperature predictor for parall
 
 A running version of the webserver is here:
 
-http://virtualchemistry.org/remd-temperature-generator/
+https://virtualchemistry.org/remd-temperature-generator/


### PR DESCRIPTION
The link to the Webserver doesn't work without https (tested with safari & chrome on Mac), this should fix it :)